### PR TITLE
BXMSDOC-3064-master: Pull request for correcting product installation link in Prerequisites section

### DIFF
--- a/docs/product-assembly_interacting-with-processes/src/main/asciidoc/main.adoc
+++ b/docs/product-assembly_interacting-with-processes/src/main/asciidoc/main.adoc
@@ -13,7 +13,7 @@ As a knowledge worker, you use {CENTRAL} in {PRODUCT} to run processes and tasks
 
 .Prerequisites
 * Installed Red Hat JBoss Enterprise Application Platform 7.1.0. For more information, see {URL_INSTALLING_ON_EAP}[_{INSTALLING_ON_EAP}_].
-* Installed {PRODUCT}. For more information, see the {URL_INSTALLING_DM_ON_PREMISE}[_{INSTALLING_DM_ON_PREMISE}_].
+* Installed {PRODUCT}. For more information, see {URL_PLANNING_INSTALL}[_{PLANNING_INSTALL}_].
 * {PRODUCT} is running and you can log in to {CENTRAL} with the user role.
 
 // Modules - concepts, procedures, refs, etc.


### PR DESCRIPTION
This is a pull request for correcting the _product installation_ link in **Prerequisites** section of **Interacting with processes and tasks** document.

[Documentation JIRA](https://issues.jboss.org/browse/BXMSDOC-3064)
[Rendered Output](http://file.pnq.redhat.com/~gadey/BXMSDOC-2334/)