### PR TITLE
BXMSDOC-3483: Added cross-refs for process instance logs & process administration sections

### DIFF
--- a/doc-content/enterprise-only/processes/process-definitions-con.adoc
+++ b/doc-content/enterprise-only/processes/process-definitions-con.adoc
@@ -8,4 +8,4 @@ The process definition list shows all the available process definitions that are
 
 You can also define the default pagination option for all users under Manage (Process Definition, Process Instances, Tasks, Jobs and Execution Errors) and Task Inbox menu. For more information, see <<{enterprise-dir}/processes/admin-and-config/managing-business-central-process-administration-con.adoc#,Process administration>>.
 
-In the process definition details section, you can click the *Diagram* tab to view associated BPMN2-based diagram of the process definition . You can also deploy a new process instance for the process definition by clicking the *New Process Instance* button in the upper-right corner.
+In the process definition details section, you can click the *Diagram* tab to view associated BPMN2-based diagram of the process definition . You can also start a new process instance for the process definition by clicking the *New Process Instance* button in the upper-right corner.

--- a/doc-content/enterprise-only/processes/process-definitions-con.adoc
+++ b/doc-content/enterprise-only/processes/process-definitions-con.adoc
@@ -2,9 +2,10 @@
 
 = Process definitions
 
-After you have created, configured, and deployed your project that includes your business processes, you can view the list of all the process definitions in *Menu* → *Manage* → *Process Definitions*. You can refresh the list of deployed process definitions at any time by clicking the refresh button in the upper-right corner. 
+After you have created, configured, and deployed your project that includes your business processes, you can view the list of all the process definitions in *Menu* → *Manage* → *Process Definitions*. You can refresh the list of deployed process definitions at any time by clicking the refresh button in the upper-right corner.
 
 The process definition list shows all the available process definitions that are deployed into the platform. Click on any of the process definitions listed to show the corresponding process definition details. This displays information about the process definition, such as if there is a sub-process associated with it, or how many users and groups exist in the process definition.
 
-In the process definition details section, you can click the *Diagram* tab to view associated BPMN2-based diagram of the process definition . You can also deploy a new process instance for the process definition by clicking the *New Process Instance* button in the upper-right corner.
+You can also define the default pagination option for all users under Manage (Process Definition, Process Instances, Tasks, Jobs and Execution Errors) and Task Inbox menu. For more information, see <<{enterprise-dir}/processes/admin-and-config/managing-business-central-process-administration-con.adoc#,Process administration>>.
 
+In the process definition details section, you can click the *Diagram* tab to view associated BPMN2-based diagram of the process definition . You can also deploy a new process instance for the process definition by clicking the *New Process Instance* button in the upper-right corner.

--- a/doc-content/enterprise-only/processes/process-instance-details-con.adoc
+++ b/doc-content/enterprise-only/processes/process-instance-details-con.adoc
@@ -15,8 +15,8 @@ image::processes/processinstancedetails.png[]
 * The *Instance Details* tab: This gives you a quick overview about what is going on inside the process. It displays the current state of the instance and the current activity that is being executed.
 * The *Process Variables* tab: This displays all of the process variables that are being manipulated by the instance, with the exception of the variables that contain documents. Additionally, you can edit the process variable value and view its history.
 * The *Documents* tab: This displays process documents if the process contains a variable of the type *org.jbpm.Document*. This enables easy access, download, and manipulation of the attached documents.
-* The *Logs* tab: This displays business and technical logs for the respective end users. 
-* The *Diagram* tab: This tracks the progress of the process instance through the BPMN2 diagram. The node or nodes of the process flow that are in progress are highlighted in red. 
+* The *Logs* tab: This displays business and technical logs for the respective end users. For more information, see <<{enterprise-dir}/processes/interacting-with-processes-viewing-process-instance-history-log-proc.adoc#,Viewing process instance logs>>.
+* The *Diagram* tab: This tracks the progress of the process instance through the BPMN2 diagram. The node or nodes of the process flow that are in progress are highlighted in red.
 
 
 ifdef::PAM[]

--- a/doc-content/enterprise-only/processes/process-instance-details-con.adoc
+++ b/doc-content/enterprise-only/processes/process-instance-details-con.adoc
@@ -15,7 +15,7 @@ image::processes/processinstancedetails.png[]
 * The *Instance Details* tab: This gives you a quick overview about what is going on inside the process. It displays the current state of the instance and the current activity that is being executed.
 * The *Process Variables* tab: This displays all of the process variables that are being manipulated by the instance, with the exception of the variables that contain documents. Additionally, you can edit the process variable value and view its history.
 * The *Documents* tab: This displays process documents if the process contains a variable of the type *org.jbpm.Document*. This enables easy access, download, and manipulation of the attached documents.
-* The *Logs* tab: This displays business and technical logs for the respective end users. For more information, see <<{enterprise-dir}/processes/interacting-with-processes-viewing-process-instance-history-log-proc.adoc#,Viewing process instance logs>>.
+* The *Logs* tab: This displays process instance logs for the respective end users. For more information, see <<{enterprise-dir}/processes/interacting-with-processes-viewing-process-instance-history-log-proc.adoc#,Viewing process instance logs>>.
 * The *Diagram* tab: This tracks the progress of the process instance through the BPMN2 diagram. The node or nodes of the process flow that are in progress are highlighted in red.
 
 


### PR DESCRIPTION
In this PR, 2 cross refs have been added to existing document for pointing to viewing process instance logs & process administration documents. No other changes have been made.

[Jira ID](https://issues.jboss.org/browse/BXMSDOC-3483)
[Rendered Output](http://file.pnq.redhat.com/~gadey/BXMSDOC-3483/)
